### PR TITLE
add django-cors-headers to pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ waitress = "*"
 moviepy = "*"
 psycopg2 = "*"
 django-environ = "*"
+django-cors-headers = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
Не хватало django-cors-headers в pip файле 